### PR TITLE
Dynamic formatting

### DIFF
--- a/paste_this_to_webui_scripts_folder/prompt_gallery.py
+++ b/paste_this_to_webui_scripts_folder/prompt_gallery.py
@@ -460,7 +460,10 @@ def load_prompt(file, default_negative, dropdown, skip_exist):
     if dropdown == '' or file is None:
         return
     rawDict = yaml.load(file, Loader = yaml.BaseLoader)
-    default_negative = default_negative + ', ' + avatar_negatives[avatar_names.index(dropdown)] 
+    if len(default_negative) != 0:
+        default_negative = default_negative + ', ' + avatar_negatives[avatar_names.index(dropdown)]
+    else:
+        default_negative = avatar_negatives[avatar_names.index(dropdown)]
     parse_yaml_dict(rawDict, "", avatar_prompts[avatar_names.index(dropdown)], dropdown, default_negative)
     prompt_txt = ""
     keys = list(filter(lambda x: x not in EXCLUDED_TAGS, OUTPUTS.keys()))

--- a/paste_this_to_webui_scripts_folder/prompt_gallery.py
+++ b/paste_this_to_webui_scripts_folder/prompt_gallery.py
@@ -454,13 +454,21 @@ def save_styles() -> None:
         shutil.move(path, path + ".bak")
     shutil.move(temp_path, path)
 
-def load_prompt(file, dropdown, skip_exist):
+def load_prompt(file, default_positive, default_negative, dropdown, skip_exist):
     global SKIP_EXISTS
     SKIP_EXISTS = skip_exist
     if dropdown == '' or file is None:
         return
     rawDict = yaml.load(file, Loader = yaml.BaseLoader)
-    parse_yaml_dict(rawDict, "", avatar_prompts[avatar_names.index(dropdown)], dropdown, avatar_negatives[avatar_names.index(dropdown)])
+    if len(default_positive) != 0:
+        default_positive = avatar_prompts[avatar_names.index(dropdown)] + ', ' + default_positive
+    else:
+        default_positive = avatar_prompts[avatar_names.index(dropdown)]
+    if len(default_negative) != 0:
+        default_negative = avatar_negatives[avatar_names.index(dropdown)] + ', ' + default_negative
+    else:
+        default_negative = avatar_negatives[avatar_names.index(dropdown)]
+    parse_yaml_dict(rawDict, "", default_positive, dropdown, default_negative)
     prompt_txt = ""
     keys = list(filter(lambda x: x not in EXCLUDED_TAGS, OUTPUTS.keys()))
     for style in keys:
@@ -468,23 +476,19 @@ def load_prompt(file, dropdown, skip_exist):
             prompt_txt += each_line + '\n'
     return [prompt_txt, gr.Row.update(visible=True)]
 
-def load_avartar(avatar_dict, default_positive, default_negative):
+def load_avartar(avatar_dict):
     avatars = yaml.load(avatar_dict, yaml.BaseLoader)
 
     for name, prompt in avatars.items():
         avatar_names.append(name)
-        if 'value' in prompt.keys() and len(default_positive) != 0:
-            avatar_prompts.append(prompt['value'] + ', ' + default_positive)
-        elif 'value' in prompt.keys():
+        if 'value' in prompt.keys():
             avatar_prompts.append(prompt['value'])
         else:
-            avatar_prompts.append(default_positive + ', ')
-        if 'negative' in prompt.keys() and len(default_negative) != 0:
-            avatar_negatives.append(prompt['negative'] + ', ' + default_negative)
-        elif 'negative' in prompt.keys():
+            avatar_prompts.append('')
+        if 'negative' in prompt.keys():
             avatar_negatives.append(prompt['negative'])
         else:
-            avatar_negatives.append(default_positive + ', ')
+            avatar_negatives.append('')
     return [gr.Dropdown.update(choices=avatar_names, value=avatar_names[0]), gr.Column.update(visible=True),  gr.Group.update(visible=True)] 
 
 def scan_outputs(avatar_name):
@@ -631,7 +635,7 @@ class Script(scripts.Script):
             prompt_display = gr.Textbox(label="List of prompt inputs", lines=1)
 
         
-        prompt_dict.change(fn=load_prompt, inputs=[prompt_dict, dropdown, skip_exist], outputs=[prompt_display, save_prompts])
+        prompt_dict.change(fn=load_prompt, inputs=[prompt_dict, default_positive, default_negative, dropdown, skip_exist], outputs=[prompt_display, save_prompts])
         open_button.click(fn=lambda: open_folder(OUTPATH_SAMPLES), inputs=[], outputs=[])
         export_button.click(fn=save_styles, inputs=[], outputs=[])
 
@@ -659,7 +663,7 @@ class Script(scripts.Script):
         rename_button.click(fn=rename_preview, inputs=[dropdown], outputs=[])
             # qc_select.click(fn=scan_outputs, inputs=[], outputs=[preview_dropdown])
 
-        avatar_dict.change(fn=load_avartar, inputs=[avatar_dict, default_positive, default_negative], outputs=[dropdown, avatar_col, qc_widgets])
+        avatar_dict.change(fn=load_avartar, inputs=[avatar_dict], outputs=[dropdown, avatar_col, qc_widgets])
         return [checkbox_iterate, avatar_dict, prompt_dict, default_negative, default_positive, dropdown, prompt_display, rename_button, label_avatar, open_button, export_button, skip_exist, label_presets, label_preview, preview_dropdown, preview_gallery, qc_select, qc_refresh, qc_show, selected_img]
 
     def run(self, p, checkbox_iterate, avatar_dict, prompt_dict, default_negative, default_positive, dropdown, prompt_display, rename_button, label_avatar, open_button, export_button, skip_exist, label_presets, label_preview, preview_dropdown, preview_gallery, qc_select, qc_refresh, qc_show, selected_img):

--- a/paste_this_to_webui_scripts_folder/prompt_gallery.py
+++ b/paste_this_to_webui_scripts_folder/prompt_gallery.py
@@ -347,9 +347,9 @@ def parse_yaml_dict(rawDict, tag, avatar_prompt, avatar_name, default_negative):
                 params = parse_param(rawDict['param'])
                 parsed_param = True
             elif key == 'value':
-                m_positive = value + m_positive
+                m_positive = m_positive + ', ' + value
             elif key == 'negative':
-                m_negative = value +','+ m_negative
+                m_negative = m_negative + ', ' + value
 
         cur += "--{key} \"{value}\" ".format(key='prompt', value= m_positive)
         cur += "--{key} \"{value}\" ".format(key='negative_prompt', value= m_negative)
@@ -460,7 +460,7 @@ def load_prompt(file, default_negative, dropdown, skip_exist):
     if dropdown == '' or file is None:
         return
     rawDict = yaml.load(file, Loader = yaml.BaseLoader)
-    default_negative = default_negative + ',' + avatar_negatives[avatar_names.index(dropdown)] 
+    default_negative = default_negative + ', ' + avatar_negatives[avatar_names.index(dropdown)] 
     parse_yaml_dict(rawDict, "", avatar_prompts[avatar_names.index(dropdown)], dropdown, default_negative)
     prompt_txt = ""
     keys = list(filter(lambda x: x not in EXCLUDED_TAGS, OUTPUTS.keys()))


### PR DESCRIPTION
This patchset fixes a few issues i noticed on initial testing:
1. The "default_positive" field did not work
2. There were commas added even if fields like "default_negative" were empty
3. A space should be inserted after every (actually placed) comma
4. IMO the arguments were added on the wrong side of the prompt


Nr. 1 Is caused by the textboxes not holding the correct value when load_avartar() is called. Neither on initial load, nor when changing the selection or uploading a new file. Moving "default_negative" into `load_avartar()` stopps it from working as well [see this commit](https://github.com/HPPinata/PromptGallery-stable-diffusion-webui/commit/90961c2589e261bb738326fc7f9bc7a07bd156ab,) so just move both to `load_prompt()`. This also makes their handeling consistent.

Nr. 2 Is fixed by checking `if len(default_) != 0` before adding any input (including commas)

Nr. 3 Just some minor formatting

Nr. 4 This is optional, personal preference and can be changed (if you prefer the original order):
  Original behaviour:
  -> `tags + default_ + prompt`
  New ordering (more conventional):
  -> `prompt + default_ + tags`

This can be altered by just swapping
`m_positive + ', ' + value` -> `value + ', ' + m_positive`
and
`avatar_prompts[avatar_names.index(dropdown)] + ', ' + default_positive` ->
`default_positive + ', ' + avatar_prompts[avatar_names.index(dropdown)]`

(Obviously doing the same for the negative version)

I tried keeping the changes minimal and hope you like them enough to merge them into your amazing project